### PR TITLE
Use clr_out variable in show_embedding plot.

### DIFF
--- a/src/vis.jl
+++ b/src/vis.jl
@@ -86,7 +86,7 @@ function show_embedding(
       end
     end
     idx_cross = map( (x,y) -> x != y, L[i], L[j] )
-    _plot_lines!( ax, Y, i, j, idx_cross, colorant"#aabbbbbb", lwd_out )
+    _plot_lines!( ax, Y, i, j, idx_cross, clr_out, lwd_out )
   end
 
   scatter!(ax, Y[:,1], Y[:,2], color = L, colormap = cmap,


### PR DESCRIPTION
Previously, the color of inter-cluster edges was hard coded. This changes to actually use the variable to define the color as defined in the function.